### PR TITLE
Only accessing _controller when it is a Controller

### DIFF
--- a/Controller/Component/PresenterComponent.php
+++ b/Controller/Component/PresenterComponent.php
@@ -291,7 +291,9 @@ class PresenterComponent extends Component {
 	 * @access protected
 	 */
 	protected function setDefaultPresenterToController() {
-		$this->_controller->set($this->_viewVar, $this->getDefaultPresenter());
+		if ($this->_controller instanceof Controller) {
+			$this->_controller->set($this->_viewVar, $this->getDefaultPresenter());
+		}
 	}
 
 	/**


### PR DESCRIPTION
If a syntax error had been thrown, this line of code would stil run
causing the "_controller is not an object" to hide the parse error.
