### PR TITLE
Check if helper is an object

### DIFF
--- a/Presenter/Presenter.php
+++ b/Presenter/Presenter.php
@@ -138,26 +138,31 @@ class Presenter implements arrayaccess {
 	 * @return Mixed
 	 */
 	public function __get($property) {
-		if (
-			isset($this->{$this->_options['contextKey']}) &&
-			is_object($this->{$this->_options['contextKey']}) &&
-			property_exists($this->{$this->_options['contextKey']}, $property)
-		) {
-			$ret = $this->{$this->_options['contextKey']}->{$property};
-		} elseif (
-			$this->_controller &&
-			property_exists($this->_controller, 'View') &&
-			property_exists($this->_controller->View, 'Helpers') &&
-			is_object($this->_controller->View->Helpers->{$property})
-		) {
-			$ret = $this->_controller->View->Helpers->{$property};
-		} else {
+		$error = true;
+		try {
+			if (
+				isset($this->{$this->_options['contextKey']}) &&
+				is_object($this->{$this->_options['contextKey']}) &&
+				property_exists($this->{$this->_options['contextKey']}, $property)
+			) {
+				$ret = $this->{$this->_options['contextKey']}->{$property};
+				$error = false;
+			} elseif (
+				$this->_controller &&
+				property_exists($this->_controller, 'View') &&
+				property_exists($this->_controller->View, 'Helpers')
+			) {
+					$ret = $this->_controller->View->Helpers->{$property};
+					$error = !$ret;
+			}
+		} catch (MissingHelperException $e) {}
+		if ($error) {
 			$trace = debug_backtrace();
+			$t = $trace[0];
 			trigger_error(
-				'Undefined property: ' . $property .
-				' in ' . $trace[0]['file'] .
-				' on line ' . $trace[0]['line'],
-				E_USER_NOTICE);
+				"Undefined property: {$property} in {$t['file']} on line {$t['line']}",
+				E_USER_NOTICE
+			);
 		}
 		return $ret;
 	}
@@ -186,11 +191,11 @@ class Presenter implements arrayaccess {
 			$call = array($this->_controller->View, $method);
 		} else {
 			$trace = debug_backtrace();
+			$t = $trace[0];
 			trigger_error(
-				'Call to undefined method: ' . $method .
-				' in ' . $trace[0]['file'] .
-				' on line ' . $trace[0]['line'],
-				E_USER_NOTICE);
+				"Call to undefined method: {$method} in {$t['file']} on line {$t['line']}",
+				E_USER_NOTICE
+			);
 		}
 		return call_user_func_array($call, $args);
 	}

--- a/Presenter/Presenter.php
+++ b/Presenter/Presenter.php
@@ -148,7 +148,7 @@ class Presenter implements arrayaccess {
 			$this->_controller &&
 			property_exists($this->_controller, 'View') &&
 			property_exists($this->_controller->View, 'Helpers') &&
-			property_exists($this->_controller->View->Helpers, $property)
+			is_object($this->_controller->View->Helpers->{$property})
 		) {
 			$ret = $this->_controller->View->Helpers->{$property};
 		} else {

--- a/Test/Case/Presenter/PresenterTest.php
+++ b/Test/Case/Presenter/PresenterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 App::uses('Presenter', 'CakePHP-GiftWrap.Presenter');
+App::uses('View', 'View');
 
 class TestView {
 	public function viewMethod() { return 'view method'; }
@@ -98,8 +99,7 @@ class PresenterTest extends CakeTestCase {
 
 	public function testPresenterLooksForPropertyInViewHelpersIfNotDefined() {
 		$mock = $this->getMock('stdClass');
-		$mock->View = new TestView;
-		$mock->View->Helpers = new stdClass;
+		$mock->View = $this->getMock('View');
 		$mock->View->Helpers->Html = 'Html Helper';
 		$presenter = new Presenter(array(), array(), $mock);
 		$this->assertEquals('Html Helper', $presenter->Html);
@@ -107,15 +107,14 @@ class PresenterTest extends CakeTestCase {
 
 	public function testPresenterWarnsThatPropertyDoesNotExistOnPresenterWhenNotPresentInView() {
 		$mock = $this->getMock('stdClass');
-		$mock->View = new TestView;
-		$mock->View->Helpers = new stdClass;
+		$mock->View = $this->getMock('View');
 		$presenter = new Presenter(array(), array(), $mock);
 		try {
-			$presenter->Form;
+			$presenter->Time;
 		} catch (Exception $e) {
-			$this->assertRegExp('/Undefined property: Form in/', $e->getMessage());
+			$this->assertRegExp('/Undefined property: Time in/', $e->getMessage());
 			return;
 		}
-		$this->assertTrue(false, 'Missing method error not thrown');
+		$this->assertTrue(false, 'Missing property error not thrown');
 	}
 }


### PR DESCRIPTION
Using property_exists was causing helpers to not be available. Checking
if they are objects instead fixes the issue.
