### PR TITLE
Corrects Misspelling of license in composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "cakephp-plugin",
   "description": "A CakePHP Presenter/Decorator Plugin",
   "keywords": ["cakephp","helper","presenters","decorators"],
-  "licence": "MIT",
+  "license": "MIT",
   "homepage": "https://github.com/loadsys/CakePHP-GiftWrap",
   "authors": [
     {


### PR DESCRIPTION
Signed-off-by: Justin Yost justin.yost@yostivanich.com
